### PR TITLE
Update flashing instuction for Grinn AstraADA and AstraEVB

### DIFF
--- a/products/astra/common/flash_prerequisites.inc
+++ b/products/astra/common/flash_prerequisites.inc
@@ -2,7 +2,7 @@ This section provides step-by-step instructions for preparing your development h
 
 .. note::
 
-    The following instructions assume you are using Ubuntu 22.04 LTS.
+    The following instructions assume you are using Ubuntu 22.04 LTS or Windows 10/11.
 
 Install Git
 -----------
@@ -18,7 +18,7 @@ Git is required to download the ``usb-tool``. Follow these steps to ensure it is
 
     If Git is installed, this command will output its version (e.g., ``git version 2.34.1``). If you see a version number, you can skip to the next section.
 
-2.  **Install Git (if not installed):**
+2.  **Install Git (Linux):**
     If Git is not installed (e.g., the command in step 1 returns an error like "command not found"), install it using the following commands on Ubuntu:
 
     .. code-block:: bash
@@ -28,6 +28,13 @@ Git is required to download the ``usb-tool``. Follow these steps to ensure it is
 
     You will be prompted for your password and asked to confirm the installation.
 
+3. **Install Git (Windows):**
+    Use the **Microsoft Store** to install Git:
+
+    - Open the **Microsoft Store** application.
+    - Search for **Git** and install the official version (usually listed as "Git for Windows").
+    - Once installed, open **PowerShell** and verify the installation (refer to step 1).
+
 Set up the usb-tool
 -------------------
 
@@ -36,3 +43,37 @@ The ``usb-tool`` is required for flashing the device. To install it, clone the r
 .. code-block:: bash
 
     git clone https://github.com/synaptics-astra/usb-tool.git
+
+Installing the WinUSB Driver (Windows Only)
+-------------------------------------------
+
+The WinUSB driver is required on Windows to establish communication with the device's bootloader.
+
+1. **Locate the driver files:**
+   After cloning the ``usb-tool`` repository, navigate to the following directory:
+
+   ``usb-tool\Synaptics_WinUSB_Driver``
+
+2. **Install the driver:**
+   Right-click on the ``SYNA_WinUSB.inf`` file and select **Install** from the context menu.
+
+   This will install the necessary WinUSB driver for the device.
+
+   .. note::
+
+      For more detailed instructions, refer to the
+      `official documentation <https://synaptics-astra.github.io/doc/v/1.6.0/linux/index.html#installing-the-winusb-driver-windows-only>`_.
+
+Installing the VC++ Redistributable (Windows Only)
+--------------------------------------------------
+
+If you encounter errors related to missing libraries while using the flashing script, you may need to install
+the Microsoft Visual C++ Redistributable package.
+
+1. **Download the installer:**
+   Visit the `Microsoft Visual C++ Redistributable download page
+   <https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170>`_
+   to get the latest supported version.
+
+2. **Install the package:**
+   Run the downloaded installer and follow the on-screen instructions to complete the installation.

--- a/products/astra/common/flash_the_image.inc
+++ b/products/astra/common/flash_the_image.inc
@@ -29,8 +29,8 @@ To flash the |BOARD_NAME|, it must first be in **download mode**.
 
 |BOARD_IMAGE_BUTTONS|
 
-Flashing
---------
+Flashing Yocto build
+--------------------
 
 Once the ``usb-tool`` is ready and your device is in download mode, you can proceed with flashing the firmware.
 
@@ -44,27 +44,40 @@ Once the ``usb-tool`` is ready and your device is in download mode, you can proc
 
 2. **Execute the flashing process.**
 
-   Use the ``flash-grinn-astra.sh`` helper script to flash your device, specifying the path to ``usb-tool`` and selecting the |BOARD_NAME| platform (|FLASH_SCRIPT_PLATFORM_SELECTOR|).
+   Use the ``flash-grinn-astra.py`` helper script to flash your device, specifying the path to ``usb-tool`` and selecting the |BOARD_NAME| platform (|FLASH_SCRIPT_PLATFORM_SELECTOR|).
    The proper image will be selected from the Yocto build tree automatically:
 
    .. code-block:: bash
 
-      ./src/meta-grinn-astra/scripts/flash-grinn-astra <path/to/usb-tool> <platform_selector>
-
-   If you have a pre-built image to be flashed, you can specify the path to the image manually:
-
-   .. code-block:: bash
-
-      ./src/meta-grinn-astra/scripts/flash-grinn-astra <path/to/usb-tool> <platform_selector> <path/to/prebuilt/image>
+      python src/meta-grinn-astra/scripts/flash-grinn-astra <path/to/usb-tool> <platform_selector>
 
    After the flashing is complete, an appropriate success message will appear in the script's output.
-
 
 .. note::
 
    The script will display progress updates in your terminal.
 
    **Do not disconnect your device or interrupt the process until it completes successfully.**
+
+Flashing a Prebuilt Image
+-------------------------
+
+If you have a prebuilt firmware image (in `.zip` format), extract it and follow the steps below to flash it manually:
+
+1. **Download and extract** the firmware archive into a directory (e.g., `image`).
+
+2. **Run the flashing script with image path specified:**
+
+   .. code-block:: bash
+
+      python flash-grinn-astra.py </path/to/your/usb-tool> <platform_selector> [/path/to/prebuilt/image]
+
+   On Windows:
+
+   .. code-block:: powershell
+
+      python flash-grinn-astra.py <\\path\\to\\your\\usb-tool> <platform_selector> [\\path\\to\\prebuilt\\image]
+
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
- Added requirements to install on Windows platform.
- The information about flashing the prebuilt image was separated to make it more visible.
- Changed flash-grinn-astra.sh to the Python version flash-grinn-astra.py because it is verified and will be unified for both platforms.