### PR TITLE
Add reusable device access guide, standardize formatting, and improve flashing procedures

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -11,3 +11,16 @@ footer > .container {
 #content ul:not(.search) {
   margin-top: 1rem !important;
 }
+
+/* Wider content view */
+@media (min-width: 1600px) {
+  .container {
+    max-width: 1600px !important;
+  }
+}
+
+/* Link styles */
+#content a:not(.toc-backref) {
+  text-underline-offset: 2px !important;
+  text-decoration-thickness: 1px !important;
+}

--- a/index.rst
+++ b/index.rst
@@ -9,9 +9,12 @@ Embedded Platforms Docs
    products/astra/index
    products/genio/index
 
-This documentation covers all aspects of working with Grinn's embedded platforms from the Astra and Genio series. It includes detailed information on the hardware, software, and development tools available for these platforms, as well as step-by-step guides for building and flashing images.
+This wiki provides comprehensive technical documentation for Grinn's Astra and Genio embedded platform series.
+It covers hardware specification, supported software, development tools, and step-by-step instructions for building and flashing firmware images.
 
-Whether you're evaluating the hardware or integrating it into your production environment, this guide provides the necessary steps to help you get started quickly and effectively.
+The source code and build tools are available on the official `Grinn GitHub organization <https://github.com/grinn-global>`_.
+
+For detailed specifications and additional resources, visit the `Grinn product pages <https://grinn-global.com/products>`_.
 
 Grinn AstraADA-1680
 -------------------

--- a/products/astra/common/flash_prerequisites.inc
+++ b/products/astra/common/flash_prerequisites.inc
@@ -28,14 +28,11 @@ Git is required to download the ``usb-tool``. Follow these steps to ensure it is
 
     You will be prompted for your password and asked to confirm the installation.
 
-Set up ``usb-tool``
+Set up the usb-tool
 -------------------
 
-The ``usb-tool`` is essential for flashing the device. With Git installed, follow these steps to set it up:
+The ``usb-tool`` is required for flashing the device. To install it, clone the repository:
 
-* **Clone the repository:**
-    Open a terminal and clone the ``usb-tool`` repository from GitHub:
+.. code-block:: bash
 
-    .. code-block:: bash
-
-        git clone https://github.com/synaptics-astra/usb-tool.git
+    git clone https://github.com/synaptics-astra/usb-tool.git

--- a/products/astra/common/flash_the_image.inc
+++ b/products/astra/common/flash_the_image.inc
@@ -5,7 +5,7 @@ This section details the steps for flashing your device. Ensure you've completed
 
     See previous sections for details on building or downloading the image.
 
-Connect the board
+Connect the Board
 -----------------
 
 Flashing |BOARD_NAME| requires:
@@ -15,16 +15,15 @@ Flashing |BOARD_NAME| requires:
 
 |BOARD_IMAGE_PORTS|
 
-Manually enabling download mode
--------------------------------
+Download Mode
+-------------
 
-To flash the |BOARD_NAME|, it must first be in **download mode**. Follow these steps carefully:
+To flash the |BOARD_NAME|, it must first be in **download mode**.
 
-* **Locate the buttons**: Find the **RESET** and **USB_BOOT** buttons on your device. Refer to picture below for details.
-* **Enter bootloader sequence**:
-    * **Press and hold** both the **RESET** and **USB_BOOT** buttons simultaneously.
-    * While still holding **USB_BOOT**, **release RESET**.
-    * Wait a moment, then **release USB_BOOT**.
+1. Locate the **RESET** and **USB_BOOT** buttons on your device (see the picture below).
+2. Press and hold both buttons at the same time.
+3. While still holding **USB_BOOT**, release **RESET**.
+4. After a brief pause, release **USB_BOOT**.
 
 |BOARD_NAME| should now be in download mode.
 
@@ -35,49 +34,60 @@ Flashing
 
 Once the ``usb-tool`` is ready and your device is in download mode, you can proceed with flashing the firmware.
 
-* **Navigate to the root directory of your Yocto build**
-    Open new terminal (do not use Grinn Yocto Docker container) and navigate to the root directory of your |BOARD_NAME| Yocto build.
+1. **Navigate to the root directory of your Yocto build.**
 
-    .. code-block:: bash
+   Open a new terminal (do not use the Grinn Yocto Docker container) and navigate to the root directory of your |BOARD_NAME| Yocto build.
 
-        cd /path/to/your/yocto/main/directory
+   .. code-block:: bash
 
-* **Execute the flashing process**:
-    Use the ``flash-grinn-astra.sh`` helper script to flash your device, specifying the path to ``usb-tool`` and selecting |BOARD_NAME| platform (|FLASH_SCRIPT_PLATFORM_SELECTOR|).
-    Proper image will be selected from Yocto build tree automatically:
+      cd /path/to/your/yocto/main/directory
 
-    .. code-block:: bash
+2. **Execute the flashing process.**
 
-        ./src/meta-grinn-astra/scripts/flash-grinn-astra </path/to/your/usb-tool> <platform_selector>
+   Use the ``flash-grinn-astra.sh`` helper script to flash your device, specifying the path to ``usb-tool`` and selecting the |BOARD_NAME| platform (|FLASH_SCRIPT_PLATFORM_SELECTOR|).
+   The proper image will be selected from the Yocto build tree automatically:
 
-    If you have a pre-built image to be flashed you can specify path to the image manually:
+   .. code-block:: bash
 
-    .. code-block:: bash
+      ./src/meta-grinn-astra/scripts/flash-grinn-astra <path/to/usb-tool> <platform_selector>
 
-        ./src/meta-grinn-astra/scripts/flash-grinn-astra </path/to/your/usb-tool> <platform_selector> [/path/to/pre/built/image]
+   If you have a pre-built image to be flashed, you can specify the path to the image manually:
+
+   .. code-block:: bash
+
+      ./src/meta-grinn-astra/scripts/flash-grinn-astra <path/to/usb-tool> <platform_selector> <path/to/prebuilt/image>
+
+   After the flashing is complete, an appropriate success message will appear in the script's output.
+
 
 .. note::
 
-   * **Monitor the flashing process**: The script will display progress updates in your terminal. **Do not disconnect your device or interrupt the process** until it completes successfully.
-   * **Verify the flashing (optional but recommended)**: After the flashing is complete, an appropriate success message will appear in the script's output.
+   The script will display progress updates in your terminal.
+
+   **Do not disconnect your device or interrupt the process until it completes successfully.**
 
 Troubleshooting
 ---------------
 
-* **Failed to boot device / Device not detected**:
-    * **Common Messages**:
-        * "Boot Failed: Timeout during boot, press RESET while holding USB_BOOT to try again"
-        * "Failed to Boot Device"
-    * **Solution**:
-        * Confirm your device is correctly in download mode by repeating the steps in the ``Manually enabling download mode`` section.
-        * Check your USB cable and connection.
+**Failed to boot device / Device not detected**
 
-* **Flashing tool errors**:
-    * Ensure you are running the command with ``sudo``.
-    * Double-check the command syntax and the path to your firmware image.
-    * Refer to the ``usb-tool``'s documentation or its GitHub repository for specific error messages.
+You might see messages such as:
 
-* **Flashing fails mid-process**:
-    * **Do not disconnect the device**.
-    * Put the device back into bootloader mode by repeating the steps in the ``Manually enabling download mode section`` and attempt to re-flash.
-    * If the issue persists, your firmware image might be corrupted, or there could be a hardware issue with your device.
+.. code-block:: none
+
+   Boot Failed: Timeout during boot, press RESET while holding USB_BOOT to try again
+   Failed to Boot Device
+
+To resolve this, ensure the device is correctly in download mode by repeating the steps in the ``Download Mode`` section. Also check your USB cable and connection.
+
+**Flashing tool errors**
+
+Make sure you are running the command with ``sudo``. Double-check the command syntax and the path to your firmware image.
+
+For specific error messages, refer to the ``usb-tool`` documentation.
+
+**Flashing fails mid-process**
+
+Do not disconnect the device. Put it back into bootloader mode by repeating the ``Download Mode`` steps, then try flashing again.
+
+If the problem continues, the firmware image might be corrupted or there could be a hardware issue with the device.

--- a/products/astra/grinn-astra-1680-ada/access_device.rst
+++ b/products/astra/grinn-astra-1680-ada/access_device.rst
@@ -1,0 +1,6 @@
+Access the Device
+=================
+
+.. |BAUDRATE| replace:: 115200
+
+.. include:: /products/common/access_device.inc

--- a/products/astra/grinn-astra-1680-ada/index.rst
+++ b/products/astra/grinn-astra-1680-ada/index.rst
@@ -29,3 +29,4 @@ Table of Contents
    build_the_image
    flash_prerequisites
    flash_the_image
+   access_device

--- a/products/astra/grinn-astra-1680-evb/access_device.rst
+++ b/products/astra/grinn-astra-1680-evb/access_device.rst
@@ -1,0 +1,6 @@
+Access the Device
+=================
+
+.. |BAUDRATE| replace:: 115200
+
+.. include:: /products/common/access_device.inc

--- a/products/astra/grinn-astra-1680-evb/build_prerequisites.rst
+++ b/products/astra/grinn-astra-1680-evb/build_prerequisites.rst
@@ -1,4 +1,4 @@
 Build Prerequisites
-========================
+===================
 
 .. include:: /products/common/build_prerequisites.inc

--- a/products/astra/grinn-astra-1680-evb/build_the_image.rst
+++ b/products/astra/grinn-astra-1680-evb/build_the_image.rst
@@ -1,5 +1,5 @@
 Build the Image
-========================
+===============
 
 .. |PRODUCT_FAMILY| replace:: astra
 .. |MACHINE| replace:: grinn-astra-1680-evb

--- a/products/astra/grinn-astra-1680-evb/flash_prerequisites.rst
+++ b/products/astra/grinn-astra-1680-evb/flash_prerequisites.rst
@@ -1,6 +1,4 @@
 Flash Prerequisites
-========================
+===================
 
 .. include:: /products/astra/common/flash_prerequisites.inc
-
-

--- a/products/astra/grinn-astra-1680-evb/index.rst
+++ b/products/astra/grinn-astra-1680-evb/index.rst
@@ -30,3 +30,4 @@ Table of Contents
    build_the_image
    flash_prerequisites
    flash_the_image
+   access_device

--- a/products/common/access_device.inc
+++ b/products/common/access_device.inc
@@ -26,7 +26,7 @@ Ensure the board is powered on and connected via the Debug USB port.
 
       Log out and log back in for the changes to take effect.
 
-3. **Access the Console**
+3. **Access the console.**
 
    Once connected, you should see the console output.
    If the device is already booted, press Enter to get a login prompt.

--- a/products/common/access_device.inc
+++ b/products/common/access_device.inc
@@ -1,0 +1,32 @@
+Once the board is successfully flashed, you can connect to the device over a serial interface using any terminal emulator of your choice.
+
+Connecting to the Device
+------------------------
+
+Ensure the board is powered on and connected via the Debug USB port.
+
+1. **Identify the serial port.**
+
+   Determine the serial port exposed by the device:
+
+   .. code-block:: bash
+
+      ls /dev/ttyUSB*
+
+2. **Connect to the device.**
+
+   Use a terminal emulator to connect to the serial port of the device:
+
+   .. parsed-literal::
+
+      minicom -D /dev/ttyUSB0 -b |BAUDRATE|
+
+   .. note::
+      If you encounter permission errors, you may need to add your user to the ``dialout`` group.
+
+      Log out and log back in for the changes to take effect.
+
+3. **Access the Console**
+
+   Once connected, you should see the console output.
+   If the device is already booted, press Enter to get a login prompt.

--- a/products/common/build_prerequisites.inc
+++ b/products/common/build_prerequisites.inc
@@ -11,13 +11,13 @@ To successfully build the image, ensure your system meets the following requirem
 - Internet connection
 
 Install the ``repo`` Tool
-----------------------------
+-------------------------
 
 To install the ``repo`` tool, follow instructions from the `official Repo website <https://gerrit.googlesource.com/git-repo>`_.
 
 
 Install the ``docker`` Tool
-------------------------------
+---------------------------
 
 The installation process varies depending on your operating system.
 To install the ``docker`` tool, follow instructions from the `official Docker website <https://docs.docker.com/engine/install/>`_.

--- a/products/common/build_prerequisites.inc
+++ b/products/common/build_prerequisites.inc
@@ -10,13 +10,13 @@ To successfully build the image, ensure your system meets the following requirem
 - At least 16 GiB of RAM
 - Internet connection
 
-Install the ``repo`` Tool
+Install the Repo Tool
 -------------------------
 
 To install the ``repo`` tool, follow instructions from the `official Repo website <https://gerrit.googlesource.com/git-repo>`_.
 
 
-Install the ``docker`` Tool
+Install the Docker Tool
 ---------------------------
 
 The installation process varies depending on your operating system.

--- a/products/genio/common/flash_prerequisites.inc
+++ b/products/genio/common/flash_prerequisites.inc
@@ -58,17 +58,18 @@ If ``dialout`` is not listed, add your user to the group.
 Install Serial Terminal Emulator
 --------------------------------
 
-Install the preferred Serial Terminal Emulator tool.
-The following command installs the recommended terminal emulator ``minicom``.
+Install the preferred serial terminal emulator. This tool is used to connect to the device's console over a serial interface.
+
+Throughout this guide, the ``minicom`` terminal emulator is used.
 
 .. code-block::
 
     sudo apt install minicom
 
-Install ``genio-tools``
+Install genio-tools
 -----------------------
 
-Install the ``genio-tools`` package using pip.
+Install the ``genio-tools`` package:
 
 .. code-block::
 

--- a/products/genio/common/flash_prerequisites.inc
+++ b/products/genio/common/flash_prerequisites.inc
@@ -87,13 +87,8 @@ output the following summary:
 .. code-block::
 
     fastboot: OK
-    udev rules: OK (md5: a3b2767b42ee01d7c62bf394400528ae)
+    udev rules: OK
     Serial device write access: OK
-
-.. note::
-
-    Updates may change the expected udev rules file content, so
-    the MD5 hash might be different than above.
 
 In case of any errors follow instructions provided by the tool or consult
 `MediaTek IoT Yocto <https://mediatek.gitlab.io/aiot/doc/aiot-dev-guide/master/sw/yocto/get-started/env-setup/flash-env-linux.html>`_

--- a/products/genio/common/flash_prerequisites.inc
+++ b/products/genio/common/flash_prerequisites.inc
@@ -9,7 +9,7 @@ This section provides step-by-step instructions for preparing your development h
     documentation.
 
 Install Fastboot
-------------------------
+----------------
 
 Fastboot is used by Genio tools to flash the image.
 

--- a/products/genio/common/flash_the_image.inc
+++ b/products/genio/common/flash_the_image.inc
@@ -5,7 +5,7 @@ This section details the steps for flashing your device. Ensure you've completed
 
     See previous sections for details on building or downloading the image.
 
-Connect the board
+Connect the Board
 *****************
 
 Flashing |BOARD_NAME| requires:
@@ -33,23 +33,24 @@ into the |BOARD_NAME|.
   mode.
 
   It can be omitted, however then the board must be put into download mode manually, as listed in the section
-  `Manually enabling download mode`_.
+  `Download Mode`_.
 
 Successful flash procedure will report multiple erase and write cycles
 resulting in no errors.
 
-DTBO
-----
+Device Tree Blob Overlays
+-------------------------
+
 By default basic video, GPU and APU DTBOs are loaded.
 
-All available DTBOs can be listed using command:
+All available DTBOs can be listed using the following command:
 
 .. code-block::
 
     genio-flash --list-dtbo
 
 
-and selected using ``--load-dtbo`` switch.
+To select a DTBO, use the ``--load-dtbo`` switch.
 
 .. admonition:: Loading DTBO example
 
@@ -61,20 +62,19 @@ and selected using ``--load-dtbo`` switch.
     genio-flash -d 2 --load-dtbo camera-imx214-csi0-imx214-csi1.dtbo
 
 ``genio-flash`` also provides interactive interface to select
-DTBOs which is enabled using ``-I`` switch.
+DTBOs which can be invoked with the ``-I`` switch.
 
-Manually enabling download mode
-*******************************
+Download Mode
+*************
 
-The |BOARD_NAME| can be switched into download mode manually
-using buttons.
+The |BOARD_NAME| can be put into download mode manually using physical buttons.
 
 |IMG_BUTTON|
 
 The following sequence should be used:
 
-1. Press and keep **Download** button pressed.
+1. Press and hold the **Download** button.
 
-2. Press and release **Reset** button.
+2. Press and release the **Reset** button.
 
-3. Keep **Download** pressed until ``Erasing 'mmc0'``  is shown.
+3. Keep the **Download** button pressed until ``Erasing 'mmc0'``  is shown.

--- a/products/genio/grinn-genio-510-sbc/access_device.rst
+++ b/products/genio/grinn-genio-510-sbc/access_device.rst
@@ -1,0 +1,6 @@
+Access the Device
+=================
+
+.. |BAUDRATE| replace:: 115200
+
+.. include:: /products/common/access_device.inc

--- a/products/genio/grinn-genio-510-sbc/build_prerequisites.rst
+++ b/products/genio/grinn-genio-510-sbc/build_prerequisites.rst
@@ -1,4 +1,4 @@
 Build Prerequisites
-========================
+===================
 
 .. include:: /products/common/build_prerequisites.inc

--- a/products/genio/grinn-genio-510-sbc/build_the_image.rst
+++ b/products/genio/grinn-genio-510-sbc/build_the_image.rst
@@ -1,5 +1,6 @@
 Build the Image
-========================
+===============
+
 .. |PRODUCT_FAMILY| replace:: genio
 .. |MACHINE| replace:: grinn-genio-510-sbc
 .. |IMAGE| replace:: rity-demo-image

--- a/products/genio/grinn-genio-510-sbc/flash_prerequisites.rst
+++ b/products/genio/grinn-genio-510-sbc/flash_prerequisites.rst
@@ -1,4 +1,4 @@
 Flash Prerequisites
-========================
+===================
 
 .. include:: /products/genio/common/flash_prerequisites.inc

--- a/products/genio/grinn-genio-510-sbc/index.rst
+++ b/products/genio/grinn-genio-510-sbc/index.rst
@@ -29,3 +29,4 @@ Table of Contents
    build_the_image
    flash_prerequisites
    flash_the_image
+   access_device

--- a/products/genio/grinn-genio-700-evb/access_device.rst
+++ b/products/genio/grinn-genio-700-evb/access_device.rst
@@ -1,0 +1,6 @@
+Access the Device
+=================
+
+.. |BAUDRATE| replace:: 115200
+
+.. include:: /products/common/access_device.inc

--- a/products/genio/grinn-genio-700-evb/build_prerequisites.rst
+++ b/products/genio/grinn-genio-700-evb/build_prerequisites.rst
@@ -1,4 +1,4 @@
 Build Prerequisites
-========================
+===================
 
 .. include:: /products/common/build_prerequisites.inc

--- a/products/genio/grinn-genio-700-evb/build_the_image.rst
+++ b/products/genio/grinn-genio-700-evb/build_the_image.rst
@@ -1,5 +1,6 @@
 Build the Image
-========================
+===============
+
 .. |PRODUCT_FAMILY| replace:: genio
 .. |MACHINE| replace:: grinn-genio-700-evb
 .. |IMAGE| replace:: rity-demo-image

--- a/products/genio/grinn-genio-700-evb/flash_prerequisites.rst
+++ b/products/genio/grinn-genio-700-evb/flash_prerequisites.rst
@@ -1,6 +1,4 @@
 Flash Prerequisites
-========================
+===================
 
 .. include:: /products/genio/common/flash_prerequisites.inc
-
-

--- a/products/genio/grinn-genio-700-evb/index.rst
+++ b/products/genio/grinn-genio-700-evb/index.rst
@@ -29,3 +29,4 @@ Table of Contents
    build_the_image
    flash_prerequisites
    flash_the_image
+   access_device

--- a/products/genio/grinn-genio-700-sbc/access_device.rst
+++ b/products/genio/grinn-genio-700-sbc/access_device.rst
@@ -1,0 +1,6 @@
+Access the Device
+=================
+
+.. |BAUDRATE| replace:: 115200
+
+.. include:: /products/common/access_device.inc

--- a/products/genio/grinn-genio-700-sbc/build_prerequisites.rst
+++ b/products/genio/grinn-genio-700-sbc/build_prerequisites.rst
@@ -1,4 +1,4 @@
 Build Prerequisites
-========================
+===================
 
 .. include:: /products/common/build_prerequisites.inc

--- a/products/genio/grinn-genio-700-sbc/build_the_image.rst
+++ b/products/genio/grinn-genio-700-sbc/build_the_image.rst
@@ -1,5 +1,6 @@
 Build the Image
-========================
+===============
+
 .. |PRODUCT_FAMILY| replace:: genio
 .. |MACHINE| replace:: grinn-genio-700-sbc
 .. |IMAGE| replace:: rity-demo-image

--- a/products/genio/grinn-genio-700-sbc/flash_prerequisites.rst
+++ b/products/genio/grinn-genio-700-sbc/flash_prerequisites.rst
@@ -1,4 +1,4 @@
 Flash Prerequisites
-========================
+===================
 
 .. include:: /products/genio/common/flash_prerequisites.inc

--- a/products/genio/grinn-genio-700-sbc/index.rst
+++ b/products/genio/grinn-genio-700-sbc/index.rst
@@ -29,3 +29,4 @@ Table of Contents
    build_the_image
    flash_prerequisites
    flash_the_image
+   access_device

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Sphinx==8.1.3
-sphinxawesome-theme @ git+https://github.com/kai687/sphinxawesome-theme.git@e5c735f07b5fbfaada6895df19fe4624c8d7baae
+sphinxawesome-theme @ git+https://github.com/kai687/sphinxawesome-theme.git@edfba8a905b3ead0bede60e7e100dab901f46237


### PR DESCRIPTION
This PR introduces a reusable access_device.inc file with serial console connection instructions.

It also standardizes section titles and formatting across build and flash guides, rewrites and clarifies flashing procedures with improved step-by-step instructions, and refines explanations of download mode and script usage.

The main page and introduction are updated for better cross-linking to resources.

Updated custom CSS is added to enhance readability with a wider content layout and improved link styling.

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/0d8af670-d6f8-4f6c-9c2a-72e588fb7354) | ![after](https://github.com/user-attachments/assets/3685b9e6-12c6-4f0c-b2e0-d9ff54802f2a) |

