### PR TITLE
Remove the minicom section from flash prerequisites

### DIFF
--- a/products/genio/common/flash_prerequisites.inc
+++ b/products/genio/common/flash_prerequisites.inc
@@ -55,17 +55,6 @@ If ``dialout`` is not listed, add your user to the group.
 
     You must log out and log back in for the new group membership to take effect.
 
-Install Serial Terminal Emulator
---------------------------------
-
-Install the preferred serial terminal emulator. This tool is used to connect to the device's console over a serial interface.
-
-Throughout this guide, the ``minicom`` terminal emulator is used.
-
-.. code-block::
-
-    sudo apt install minicom
-
 Install genio-tools
 -----------------------
 


### PR DESCRIPTION
There were two install instructions in both flash and access prerequisites. The one described in the flash phase was removed as it is unrelated.