### PR TITLE
Update the TEMPLATECONF value

### DIFF
--- a/products/common/build_the_image.inc
+++ b/products/common/build_the_image.inc
@@ -36,7 +36,7 @@ Set the ``TEMPLATECONF`` environment variable and source the Yocto environment s
 
 .. parsed-literal::
 
-    export TEMPLATECONF=$(pwd)/src/meta-grinn-|PRODUCT_FAMILY|/conf/templates/default
+    export TEMPLATECONF=$(pwd)/src/meta-grinn-|PRODUCT_FAMILY|/meta-grinn-|PRODUCT_FAMILY|-bsp/conf/templates/default
     source src/poky/oe-init-build-env
 
 


### PR DESCRIPTION
TEMPLATECONF now points to a directory inside the
meta-grinn-|PRODUCT_FAMILY|-bsp folder, as the official metas were recently split into bsp and fixes.